### PR TITLE
feat(NA) - Discard older metrics on buffer overflow.

### DIFF
--- a/core/src/main/java/com/statful/client/core/sender/BufferedMetricsSender.java
+++ b/core/src/main/java/com/statful/client/core/sender/BufferedMetricsSender.java
@@ -192,8 +192,7 @@ public class BufferedMetricsSender implements MetricsSender {
     private void putRaw(final String metric) {
         boolean inserted = standardBuffer.addToBuffer(metric);
         if (!inserted) {
-            // We should discard older metrics instead
-            LOGGER.warning("The buffer is full, metric ignored!.");
+            LOGGER.warning("Failed to add metric to buffer.");
         }
 
         if (standardBuffer.isTimeToFlush()) {
@@ -204,8 +203,7 @@ public class BufferedMetricsSender implements MetricsSender {
     private void putAggregatedRaw(final String metric, final Aggregation aggregation, final AggregationFrequency aggregationFrequency) {
         boolean inserted = aggregatedBuffer.addToBuffer(metric, aggregation, aggregationFrequency);
         if (!inserted) {
-            // We should discard older metrics instead
-            LOGGER.warning("The buffer is full, metric ignored!.");
+            LOGGER.warning("Failed to add metric to buffer.");
         }
 
         if (aggregatedBuffer.isTimeToFlush()) {

--- a/core/src/test/java/com/statful/client/core/sender/BufferedMetricsSenderAPITest.java
+++ b/core/src/test/java/com/statful/client/core/sender/BufferedMetricsSenderAPITest.java
@@ -60,7 +60,7 @@ public class BufferedMetricsSenderAPITest {
     }
 
     @Test
-    public void shouldDiscardIfStandardBufferIsFull() {
+    public void shouldDiscardOlderMetricsIfStandardBufferIsFull() {
         // Given
         when(configuration.getFlushSize()).thenReturn(10000);
 
@@ -76,6 +76,7 @@ public class BufferedMetricsSenderAPITest {
         // Then
         List<String> buffer = subject.getStandardBuffer();
         assertEquals("MetricsBuffer should have 5000 metrics", 5000, buffer.size());
+        assertTrue(buffer.contains("application.test_metric_overflow 500 123456789 100"));
     }
 
     @Test
@@ -95,6 +96,7 @@ public class BufferedMetricsSenderAPITest {
         // Then
         Map<Aggregation, Map<AggregationFrequency, List<String>>> buffer = subject.getAggregatedBuffer();
         assertEquals("MetricsBuffer should have 5000 metrics", 5000, buffer.get(Aggregation.AVG).get(AggregationFrequency.FREQ_10).size());
+        assertTrue(buffer.get(Aggregation.AVG).get(AggregationFrequency.FREQ_10).contains("application.test_metric_overflow 500 123456789 100"));
     }
 
     @Test


### PR DESCRIPTION
 This tries to remove the oldest metric of the buffer once we reach max capacity and replace it with the new metrics instead of discarding those.