### PR TITLE
fix(#12): Remove Objects::nonNull usage and set travis to use jdk7 instead of 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: java
 jdk:
-  - oraclejdk8
+  - oraclejdk7
 install: mvn install -DskipTests=true -Dcobertura.skip=true -Dmaven.javadoc.skip=true -B -V
 script: mvn clean verify

--- a/core/src/main/java/com/statful/client/core/api/MetricsSenderAPI.java
+++ b/core/src/main/java/com/statful/client/core/api/MetricsSenderAPI.java
@@ -4,8 +4,6 @@ import com.statful.client.domain.api.*;
 
 import java.util.logging.Logger;
 
-import static java.util.Objects.nonNull;
-
 /**
  * This class is an implementation of the {@link SenderAPI},
  * which uses {@link MetricsSender} to send metrics.
@@ -237,7 +235,7 @@ public final class MetricsSenderAPI implements SenderAPI {
     public void send() {
         try {
             if (isValid()) {
-                long unixTimestamp = nonNull(timestamp) ? timestamp : getUnixTimestamp();
+                long unixTimestamp = timestamp != null ? timestamp : getUnixTimestamp();
 
                 metricsSenderProxy.put(name, value, tags, aggregations, aggregationFrequency, sampleRate, namespace,
                         unixTimestamp, aggregated);


### PR DESCRIPTION
Setting source and target on build (maven build plugin or javac) doesn't guarantee that the code will be executable on those targets.