### PR TITLE
fix(#17): Change the pointcut definition to be more fine grained.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: java
 jdk:
-  - oraclejdk7
+  - openjdk7
 install: mvn install -DskipTests=true -Dcobertura.skip=true -Dmaven.javadoc.skip=true -B -V
 script: mvn clean verify

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: java
 jdk:
-  - oraclejdk8
+  - openjdk7
 install: mvn install -DskipTests=true -Dcobertura.skip=true -Dmaven.javadoc.skip=true -B -V
 script: mvn clean verify

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: java
 jdk:
-  - openjdk7
+  - oraclejdk8
 install: mvn install -DskipTests=true -Dcobertura.skip=true -Dmaven.javadoc.skip=true -B -V
 script: mvn clean verify

--- a/aspects/src/main/java/com/statful/client/aspects/StatfulAspect.java
+++ b/aspects/src/main/java/com/statful/client/aspects/StatfulAspect.java
@@ -46,7 +46,7 @@ public class StatfulAspect {
      * @throws Throwable Eventually thrown by the invoked method
      */
 
-    @Around("@annotation(timer)")
+    @Around("@annotation(timer) && execution(* *(..))")
     public final Object methodTiming(final ProceedingJoinPoint joinPoint, final Timer timer) throws Throwable {
         Tags tags = new Tags();
         tags.merge(getTags(timer));


### PR DESCRIPTION
Added "execution" to ensure that we are only capturing the execution of the method and not the method call also.

With the previous definition if an annotated method was called from weaved code it would measure both, meaning we would have an almost duplicated metric, one would include the method call also and the other would be only the execution.