### PR TITLE
#25 expose pre sampled methods

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -106,7 +106,7 @@
         </module>
         <module name="MethodLength"/>
         <module name="ParameterNumber">
-            <property name="max" value="9"/>
+            <property name="max" value="10"/>
         </module>
 
         <!-- Checks for whitespace                               -->

--- a/core/src/main/java/com/statful/client/core/StatfulClientImpl.java
+++ b/core/src/main/java/com/statful/client/core/StatfulClientImpl.java
@@ -31,13 +31,9 @@ class StatfulClientImpl implements StatfulClient {
 
     @Override
     public final SenderFacade timer(final String metricName, final long value) {
-        SenderAPI metricsSenderAPI = MetricsSenderAPI.newInstance(this).with()
-                .configuration(configuration)
+        SenderAPI metricsSenderAPI = createTimer(metricName, value, false, false)
                 .aggregations(configuration.getTimerAggregations())
-                .aggregationFrequency(configuration.getTimerAggregationFrequency())
-                .tags(configuration.getTimerTags())
-                .name("timer." + metricName)
-                .value(Long.toString(value));
+                .aggregationFrequency(configuration.getTimerAggregationFrequency());
 
         return new StatfulClientFacade(metricsSenderAPI);
     }
@@ -49,13 +45,10 @@ class StatfulClientImpl implements StatfulClient {
 
     @Override
     public final SenderFacade counter(final String metricName, final int value) {
-        SenderAPI metricsSenderAPI = MetricsSenderAPI.newInstance(this).with()
-                .configuration(configuration)
+
+        SenderAPI metricsSenderAPI = createCounter(metricName, value, false, false)
                 .aggregations(configuration.getCounterAggregations())
-                .aggregationFrequency(configuration.getCounterAggregationFrequency())
-                .tags(configuration.getCounterTags())
-                .name("counter." + metricName)
-                .value(Integer.toString(value));
+                .aggregationFrequency(configuration.getCounterAggregationFrequency());
 
         return new StatfulClientFacade(metricsSenderAPI);
     }
@@ -102,15 +95,78 @@ class StatfulClientImpl implements StatfulClient {
     }
 
     @Override
+    public SenderFacade sampledTimer(final String metricName, final long value, final Integer sampleRate) {
+        SenderAPI metricsSenderAPI = createTimer(metricName, value, false, true)
+                .aggregations(configuration.getTimerAggregations())
+                .aggregationFrequency(configuration.getTimerAggregationFrequency())
+                .sampleRate(sampleRate);
+
+        return new StatfulClientFacade(metricsSenderAPI);
+    }
+
+    @Override
+    public SenderFacade sampledCounter(final String metricName, final Integer sampleRate) {
+        return sampledCounter(metricName, 1, sampleRate);
+    }
+
+    @Override
+    public SenderFacade sampledCounter(final String metricName, final int value, final Integer sampleRate) {
+
+        SenderAPI metricsSenderAPI = createCounter(metricName, value, false, true)
+                .aggregations(configuration.getCounterAggregations())
+                .aggregationFrequency(configuration.getCounterAggregationFrequency())
+                .sampleRate(sampleRate);
+
+        return new StatfulClientFacade(metricsSenderAPI);
+    }
+
+    @Override
+    public SenderFacade sampledGauge(final String metricName, final Long value, final Integer sampleRate) {
+        return sampledGauge(metricName, value.toString(), sampleRate);
+    }
+
+    @Override
+    public SenderFacade sampledGauge(final String metricName, final Double value, final Integer sampleRate) {
+        return sampledGauge(metricName, value.toString(), sampleRate);
+    }
+
+    @Override
+    public SenderFacade sampledGauge(final String metricName, final Float value, final Integer sampleRate) {
+        return sampledGauge(metricName, value.toString(), sampleRate);
+    }
+
+    @Override
+    public SenderFacade sampledGauge(final String metricName, final Integer value, final Integer sampleRate) {
+        return sampledGauge(metricName, value.toString(), sampleRate);
+    }
+
+    @Override
+    public SenderFacade sampledPut(final String metricName, final Long value, final Integer sampleRate) {
+        return sampledPut(metricName, Long.toString(value), sampleRate);
+    }
+
+    @Override
+    public SenderFacade sampledPut(final String metricName, final Double value, final Integer sampleRate) {
+        return sampledPut(metricName, Double.toString(value), sampleRate);
+    }
+
+    @Override
+    public SenderFacade sampledPut(final String metricName, final Float value, final Integer sampleRate) {
+        return sampledPut(metricName, Float.toString(value), sampleRate);
+    }
+
+    @Override
+    public SenderFacade sampledPut(final String metricName, final Integer value, final Integer sampleRate) {
+        return sampledPut(metricName, value.toString(), sampleRate);
+    }
+
+    @Override
     public final SenderFacade aggregatedTimer(final String metricName, final long value, final Aggregation aggregation,
                                               final AggregationFrequency aggregationFrequency) {
-        SenderAPI metricsSenderAPI = MetricsSenderAPI.newInstance(this, true).with()
-                .configuration(configuration)
-                .aggregation(aggregation)
-                .aggregationFrequency(aggregationFrequency)
-                .tags(configuration.getTimerTags())
-                .name("timer." + metricName)
-                .value(Long.toString(value));
+
+        SenderAPI metricsSenderAPI = createTimer(metricName, value, true, false)
+                .aggregations(aggregation)
+                .aggregationFrequency(aggregationFrequency);
 
         return new StatfulClientFacade(metricsSenderAPI);
     }
@@ -118,7 +174,7 @@ class StatfulClientImpl implements StatfulClient {
     @Override
     public final SenderFacade aggregatedCounter(final String metricName, final int value, final Aggregation aggregation,
                                                 final AggregationFrequency aggregationFrequency) {
-        SenderAPI metricsSenderAPI = MetricsSenderAPI.newInstance(this, true).with()
+        SenderAPI metricsSenderAPI = MetricsSenderAPI.newInstance(this, true, false).with()
                 .configuration(configuration)
                 .aggregation(aggregation)
                 .aggregationFrequency(aggregationFrequency)
@@ -179,6 +235,116 @@ class StatfulClientImpl implements StatfulClient {
     }
 
     @Override
+    public SenderFacade sampledAggregatedTimer(final String metricName, final long timestamp, final Aggregation aggregation,
+                                               final AggregationFrequency aggregationFrequency, final Integer sampleRate) {
+        SenderAPI metricsSenderAPI = createTimer(metricName, timestamp, true, true)
+                .aggregations(aggregation)
+                .aggregationFrequency(aggregationFrequency)
+                .sampleRate(sampleRate);
+
+        return new StatfulClientFacade(metricsSenderAPI);
+    }
+
+    @Override
+    public SenderFacade sampledAggregatedCounter(final String metricName, final int value, final Aggregation aggregation,
+                                                 final AggregationFrequency aggregationFrequency, final Integer sampleRate) {
+        SenderAPI metricsSenderAPI = createCounter(metricName, value, true, true)
+                .aggregations(aggregation)
+                .aggregationFrequency(aggregationFrequency)
+                .sampleRate(sampleRate);
+
+        return new StatfulClientFacade(metricsSenderAPI);
+    }
+
+    @Override
+    public SenderFacade sampledAggregatedGauge(final String metricName, final Long value, final Aggregation aggregation,
+                                               final AggregationFrequency aggregationFrequency, final Integer sampleRate) {
+        SenderAPI metricsSenderAPI = createGauge(metricName, value.toString(), true, true)
+                .aggregations(aggregation)
+                .aggregationFrequency(aggregationFrequency)
+                .sampleRate(sampleRate);
+
+        return new StatfulClientFacade(metricsSenderAPI);
+    }
+
+    @Override
+    public SenderFacade sampledAggregatedGauge(final String metricName, final Double value, final Aggregation aggregation,
+                                               final AggregationFrequency aggregationFrequency, final Integer sampleRate) {
+        SenderAPI metricsSenderAPI = createGauge(metricName, value.toString(), true, true)
+                .aggregations(aggregation)
+                .aggregationFrequency(aggregationFrequency)
+                .sampleRate(sampleRate);
+
+        return new StatfulClientFacade(metricsSenderAPI);
+    }
+
+    @Override
+    public SenderFacade sampledAggregatedGauge(final String metricName, final Float value, final Aggregation aggregation,
+                                               final AggregationFrequency aggregationFrequency, final Integer sampleRate) {
+        SenderAPI metricsSenderAPI = createGauge(metricName, value.toString(), true, true)
+                .aggregations(aggregation)
+                .aggregationFrequency(aggregationFrequency)
+                .sampleRate(sampleRate);
+
+        return new StatfulClientFacade(metricsSenderAPI);
+    }
+
+    @Override
+    public SenderFacade sampledAggregatedGauge(final String metricName, final Integer value, final Aggregation aggregation,
+                                               final AggregationFrequency aggregationFrequency, final Integer sampleRate) {
+        SenderAPI metricsSenderAPI = createGauge(metricName, value.toString(), true, true)
+                .aggregations(aggregation)
+                .aggregationFrequency(aggregationFrequency)
+                .sampleRate(sampleRate);
+
+        return new StatfulClientFacade(metricsSenderAPI);
+    }
+
+    @Override
+    public SenderFacade sampledAggregatedPut(final String metricName, final Long value, final Aggregation aggregation,
+                                             final AggregationFrequency aggregationFrequency, final Integer sampleRate) {
+        SenderAPI metricsSenderAPI = createPut(metricName, Long.toString(value), true, true)
+                .aggregations(aggregation)
+                .aggregationFrequency(aggregationFrequency)
+                .sampleRate(sampleRate);
+
+        return new StatfulClientFacade(metricsSenderAPI);
+    }
+
+    @Override
+    public SenderFacade sampledAggregatedPut(final String metricName, final Double value, final Aggregation aggregation,
+                                             final AggregationFrequency aggregationFrequency, final Integer sampleRate) {
+        SenderAPI metricsSenderAPI = createPut(metricName, Double.toString(value), true, true)
+                .aggregations(aggregation)
+                .aggregationFrequency(aggregationFrequency)
+                .sampleRate(sampleRate);
+
+        return new StatfulClientFacade(metricsSenderAPI);
+    }
+
+    @Override
+    public SenderFacade sampledAggregatedPut(final String metricName, final Float value, final Aggregation aggregation,
+                                             final AggregationFrequency aggregationFrequency, final Integer sampleRate) {
+        SenderAPI metricsSenderAPI = createPut(metricName, Float.toString(value), true, true)
+                .aggregations(aggregation)
+                .aggregationFrequency(aggregationFrequency)
+                .sampleRate(sampleRate);
+
+        return new StatfulClientFacade(metricsSenderAPI);
+    }
+
+    @Override
+    public SenderFacade sampledAggregatedPut(final String metricName, final Integer value, final Aggregation aggregation,
+                                             final AggregationFrequency aggregationFrequency, final Integer sampleRate) {
+        SenderAPI metricsSenderAPI = createPut(metricName, value.toString(), true, true)
+                .aggregations(aggregation)
+                .aggregationFrequency(aggregationFrequency)
+                .sampleRate(sampleRate);
+
+        return new StatfulClientFacade(metricsSenderAPI);
+    }
+
+    @Override
     public final void put(
             final String name, final String value, final Tags tags, final Aggregations aggregations,
             final AggregationFrequency aggregationFrequency, final Integer sampleRate, final String namespace,
@@ -196,19 +362,38 @@ class StatfulClientImpl implements StatfulClient {
     }
 
     @Override
-    public final void aggregatedPut(final String name, final String value, final Tags tags,
-                                    final Aggregation aggregation, final AggregationFrequency aggregationFrequency,
-                                    final Integer sampleRate, final String namespace, final long timestamp) {
+    public void putSampled(final String name, final String value, final Tags tags, final Aggregations aggregations,
+                           final AggregationFrequency aggregationFrequency, final Integer sampleRate, final String namespace, final long timestamp) {
         if (enabled) {
             try {
-                metricsSender.aggregatedPut(name, value, tags, aggregation, aggregationFrequency, sampleRate, namespace,
-                        timestamp);
+                metricsSender.putSampled(name, value, tags, aggregations, aggregationFrequency, sampleRate, namespace, timestamp);
             } catch (Exception e) {
                 LOGGER.warning("Unable to send metric: " + e.toString());
             }
         } else {
             LOGGER.fine("Statful client is disabled. The metric was not sent.");
         }
+    }
+
+    @Override
+    public final void aggregatedPut(final String name, final String value, final Tags tags,
+                                    final Aggregation aggregation, final AggregationFrequency aggregationFrequency,
+                                    final Integer sampleRate, final String namespace, final long timestamp) {
+        if (enabled) {
+            try {
+                metricsSender.aggregatedPut(name, value, tags, aggregation, aggregationFrequency, sampleRate, namespace, timestamp);
+            } catch (Exception e) {
+                LOGGER.warning("Unable to send metric: " + e.toString());
+            }
+        } else {
+            LOGGER.fine("Statful client is disabled. The metric was not sent.");
+        }
+    }
+
+    @Override
+    public void aggregatedSampledPut(final String name, final String value, final Tags tags, final Aggregation aggregation,
+                                     final AggregationFrequency aggregationFrequency, final Integer sampleRate, final String namespace, final long timestamp) {
+
     }
 
     @Override
@@ -232,49 +417,86 @@ class StatfulClientImpl implements StatfulClient {
     }
 
     private SenderFacade put(final String metricName, final String value) {
-        SenderAPI metricsSenderAPI = MetricsSenderAPI.newInstance(this).with()
-                .configuration(configuration)
-                .aggregationFrequency(configuration.getDefaultAggregationFreq())
-                .name(metricName)
-                .value(value);
+        SenderAPI metricsSenderAPI = createPut(metricName, value, false, false)
+                .aggregationFrequency(configuration.getDefaultAggregationFreq());
 
         return new StatfulClientFacade(metricsSenderAPI);
     }
 
     private SenderFacade aggregatedPut(final String metricName, final String value, final Aggregation aggregation,
                                        final AggregationFrequency aggregationFrequency) {
-        SenderAPI metricsSenderAPI = MetricsSenderAPI.newInstance(this, true).with()
-                .configuration(configuration)
+
+        SenderAPI metricsSenderAPI = createPut(metricName, value, true, false)
                 .aggregation(aggregation)
-                .aggregationFrequency(aggregationFrequency)
-                .name(metricName)
-                .value(value);
+                .aggregationFrequency(aggregationFrequency);
 
         return new StatfulClientFacade(metricsSenderAPI);
     }
 
-    private SenderFacade gauge(final String metricName, final String value) {
-        SenderAPI metricsSenderAPI = MetricsSenderAPI.newInstance(this).with()
+    private SenderFacade sampledPut(final String metricName, final String value, final Integer sampleRate) {
+        SenderAPI metricsSenderAPI = createPut(metricName, value, false, true)
+                .aggregationFrequency(configuration.getDefaultAggregationFreq())
+                .sampleRate(sampleRate);
+
+        return new StatfulClientFacade(metricsSenderAPI);
+    }
+
+    private SenderAPI createPut(final String metricName, final String value, final boolean isAggregated,
+                                final boolean isSampled) {
+        return MetricsSenderAPI.newInstance(this, isAggregated, isSampled).with()
                 .configuration(configuration)
-                .aggregations(configuration.getGaugeAggregations())
-                .aggregationFrequency(configuration.getGaugeAggregationFrequency())
-                .tags(configuration.getGaugeTags())
-                .name("gauge." + metricName)
+                .name(metricName)
                 .value(value);
+
+    }
+
+    private SenderFacade gauge(final String metricName, final String value) {
+        SenderAPI metricsSenderAPI = createGauge(metricName, value, false, false).with()
+                .aggregations(configuration.getGaugeAggregations())
+                .aggregationFrequency(configuration.getGaugeAggregationFrequency());
 
         return new StatfulClientFacade(metricsSenderAPI);
     }
 
     private SenderFacade aggregatedGauge(final String metricName, final String value, final Aggregation aggregation,
                                          final AggregationFrequency aggregationFrequency) {
-        SenderAPI metricsSenderAPI = MetricsSenderAPI.newInstance(this, true).with()
-                .configuration(configuration)
+        SenderAPI metricsSenderAPI = createGauge(metricName, value, true, false).with()
                 .aggregation(aggregation)
-                .aggregationFrequency(aggregationFrequency)
+                .aggregationFrequency(aggregationFrequency);
+
+        return new StatfulClientFacade(metricsSenderAPI);
+    }
+
+    private SenderFacade sampledGauge(final String metricName, final String value, final Integer sampleRate) {
+        SenderAPI metricsSenderAPI = createGauge(metricName, value, true, false).with()
+                .aggregations(configuration.getGaugeAggregations())
+                .aggregationFrequency(configuration.getGaugeAggregationFrequency())
+                .sampleRate(sampleRate);
+
+        return new StatfulClientFacade(metricsSenderAPI);
+    }
+
+    private SenderAPI createGauge(final String metricName, final String value, final boolean isAggregated, final boolean isSampled) {
+        return MetricsSenderAPI.newInstance(this, isAggregated, isSampled).with()
+                .configuration(configuration)
                 .tags(configuration.getGaugeTags())
                 .name("gauge." + metricName)
                 .value(value);
+    }
 
-        return new StatfulClientFacade(metricsSenderAPI);
+    private SenderAPI createTimer(final String metricName, final long value, final boolean isAggregated, final boolean isSampled) {
+        return MetricsSenderAPI.newInstance(this, isAggregated, isSampled).with()
+                .configuration(configuration)
+                .tags(configuration.getTimerTags())
+                .name("timer." + metricName)
+                .value(Long.toString(value));
+    }
+
+    private SenderAPI createCounter(final String metricName, final int value, final boolean isAggregated, final boolean isSampled) {
+        return MetricsSenderAPI.newInstance(this, isAggregated, isSampled).with()
+                .configuration(configuration)
+                .tags(configuration.getCounterTags())
+                .name("counter." + metricName)
+                .value(Integer.toString(value));
     }
 }

--- a/core/src/main/java/com/statful/client/core/StatfulClientImpl.java
+++ b/core/src/main/java/com/statful/client/core/StatfulClientImpl.java
@@ -393,7 +393,15 @@ class StatfulClientImpl implements StatfulClient {
     @Override
     public void aggregatedSampledPut(final String name, final String value, final Tags tags, final Aggregation aggregation,
                                      final AggregationFrequency aggregationFrequency, final Integer sampleRate, final String namespace, final long timestamp) {
-
+        if (enabled) {
+            try {
+                metricsSender.aggregatedSampledPut(name, value, tags, aggregation, aggregationFrequency, sampleRate, namespace, timestamp);
+            } catch (Exception e) {
+                LOGGER.warning("Unable to send metric: " + e.toString());
+            }
+        } else {
+            LOGGER.fine("Statful client is disabled. The metric was not sent.");
+        }
     }
 
     @Override
@@ -468,7 +476,7 @@ class StatfulClientImpl implements StatfulClient {
     }
 
     private SenderFacade sampledGauge(final String metricName, final String value, final Integer sampleRate) {
-        SenderAPI metricsSenderAPI = createGauge(metricName, value, true, false).with()
+        SenderAPI metricsSenderAPI = createGauge(metricName, value, false, true).with()
                 .aggregations(configuration.getGaugeAggregations())
                 .aggregationFrequency(configuration.getGaugeAggregationFrequency())
                 .sampleRate(sampleRate);

--- a/core/src/main/java/com/statful/client/core/api/MetricsSenderAPI.java
+++ b/core/src/main/java/com/statful/client/core/api/MetricsSenderAPI.java
@@ -56,9 +56,10 @@ public final class MetricsSenderAPI implements SenderAPI {
      *
      * @param metricsSender The {@link MetricsSender}
      * @param isAggregated A {@link Boolean} flag stating if the metric is aggregated
+     * @param isSampled A {@link Boolean} flag stating if the metric is sampled
      * @return An instance of {@link SenderAPI}
      */
-    public static MetricsSenderAPI newInstance(final MetricsSender metricsSender, final boolean isAggregated) {
+    public static MetricsSenderAPI newInstance(final MetricsSender metricsSender, final boolean isAggregated, final boolean isSampled) {
         return new MetricsSenderAPI(metricsSender, isAggregated);
     }
 

--- a/core/src/main/java/com/statful/client/core/api/MetricsSenderAPI.java
+++ b/core/src/main/java/com/statful/client/core/api/MetricsSenderAPI.java
@@ -16,6 +16,7 @@ public final class MetricsSenderAPI implements SenderAPI {
 
     private MetricsSenderProxy metricsSenderProxy;
     private boolean aggregated;
+    private boolean isSampled;
 
     private String name;
     private String value;
@@ -36,9 +37,10 @@ public final class MetricsSenderAPI implements SenderAPI {
         this.aggregated = false;
     }
 
-    MetricsSenderAPI(final MetricsSender metricsSender, final boolean isAggregated) {
+    MetricsSenderAPI(final MetricsSender metricsSender, final boolean isAggregated, final boolean isSampled) {
         this.metricsSenderProxy = new MetricsSenderProxy(metricsSender);
         this.aggregated = isAggregated;
+        this.isSampled = isSampled;
     }
 
     /**
@@ -48,7 +50,7 @@ public final class MetricsSenderAPI implements SenderAPI {
      * @return An instance of {@link SenderAPI}
      */
     public static MetricsSenderAPI newInstance(final MetricsSender metricsSender) {
-        return new MetricsSenderAPI(metricsSender, false);
+        return new MetricsSenderAPI(metricsSender, false, false);
     }
 
     /**
@@ -60,7 +62,7 @@ public final class MetricsSenderAPI implements SenderAPI {
      * @return An instance of {@link SenderAPI}
      */
     public static MetricsSenderAPI newInstance(final MetricsSender metricsSender, final boolean isAggregated, final boolean isSampled) {
-        return new MetricsSenderAPI(metricsSender, isAggregated);
+        return new MetricsSenderAPI(metricsSender, isAggregated, isSampled);
     }
 
     /**
@@ -70,6 +72,15 @@ public final class MetricsSenderAPI implements SenderAPI {
      */
     public boolean isAggregated() {
         return aggregated;
+    }
+
+    /**
+     * A getter for the sampled flag.
+     *
+     * @return The sampled flag
+     */
+    public boolean isSampled() {
+        return isSampled;
     }
 
     /**
@@ -239,7 +250,7 @@ public final class MetricsSenderAPI implements SenderAPI {
                 long unixTimestamp = timestamp != null ? timestamp : getUnixTimestamp();
 
                 metricsSenderProxy.put(name, value, tags, aggregations, aggregationFrequency, sampleRate, namespace,
-                        unixTimestamp, aggregated);
+                        unixTimestamp, aggregated, isSampled);
             } else {
                 LOGGER.warning("Unable to send metric because it's not valid. Please see the client documentation.");
             }

--- a/core/src/main/java/com/statful/client/core/api/MetricsSenderProxy.java
+++ b/core/src/main/java/com/statful/client/core/api/MetricsSenderProxy.java
@@ -10,6 +10,7 @@ public class MetricsSenderProxy {
 
     /**
      * Default constructor.
+     *
      * @param metricsSender A {@link MetricsSender} implementation
      */
     public MetricsSenderProxy(final MetricsSender metricsSender) {
@@ -19,20 +20,27 @@ public class MetricsSenderProxy {
     /**
      * Proxies the put method of the {@link MetricsSender} interface.
      *
-     * @param name The name of the metric
-     * @param value The value of the metric
-     * @param tags A {@link Tags} the tags to be associated with the metric
-     * @param aggregations {@link Aggregations} with aggregations of the metric
+     * @param name                 The name of the metric
+     * @param value                The value of the metric
+     * @param tags                 A {@link Tags} the tags to be associated with the metric
+     * @param aggregations         {@link Aggregations} with aggregations of the metric
      * @param aggregationFrequency {@link AggregationFrequency} of the metric
-     * @param sampleRate The metrics sample rate
-     * @param namespace The namespace of the metric
-     * @param timestamp The timestamp associated with the metric
-     * @param isAggregated Flag stating if the metric is aggregated
+     * @param sampleRate           The metrics sample rate
+     * @param namespace            The namespace of the metric
+     * @param timestamp            The timestamp associated with the metric
+     * @param isAggregated         Flag stating if the metric is aggregated
+     * @param isSampled            Flag stating if the metric is sampled
      */
     public final void put(final String name, final String value, final Tags tags, final Aggregations aggregations,
                           final AggregationFrequency aggregationFrequency, final Integer sampleRate,
-                          final String namespace, final long timestamp, final boolean isAggregated) {
-        if (isAggregated) {
+                          final String namespace, final long timestamp, final boolean isAggregated, final boolean isSampled) {
+        if (isAggregated && isSampled) {
+            Aggregation aggregation = aggregations.getAggregations().iterator().next();
+            metricsSender.aggregatedSampledPut(name, value, tags, aggregation, aggregationFrequency, sampleRate, namespace,
+                    timestamp);
+        } else if (isSampled) {
+            metricsSender.putSampled(name, value, tags, aggregations, aggregationFrequency, sampleRate, namespace, timestamp);
+        } else if (isAggregated) {
             Aggregation aggregation = aggregations.getAggregations().iterator().next();
 
             metricsSender.aggregatedPut(name, value, tags, aggregation, aggregationFrequency, sampleRate, namespace,

--- a/core/src/test/java/com/statful/client/core/StatfulClientImplTest.java
+++ b/core/src/test/java/com/statful/client/core/StatfulClientImplTest.java
@@ -81,6 +81,38 @@ public class StatfulClientImplTest {
     }
 
     @Test
+    public void shouldSendSampledTimerMetric() {
+        // When
+        subject.sampledTimer("response_time", 1000, Integer.MAX_VALUE).send();
+
+        // Then
+        ArgumentCaptor<Tags> tagsArg = ArgumentCaptor.forClass(Tags.class);
+        ArgumentCaptor<Aggregations> aggrArg = ArgumentCaptor.forClass(Aggregations.class);
+
+        verify(metricsSender).putSampled(eq("timer.response_time"), eq("1000"), tagsArg.capture(), aggrArg.capture(), eq(AggregationFrequency.FREQ_10), eq(Integer.MAX_VALUE), eq("application"), anyLong());
+
+        // Then it should have tags
+        shouldContainDefaultTimerTags(tagsArg.getValue());
+
+        // Then it should have aggregations
+        shouldContainDefaultTimerAggregations(aggrArg.getValue());
+    }
+
+    @Test
+    public void shouldSendSampledAggregatedTimerMetric() {
+        // When
+        subject.sampledAggregatedTimer("response_time", 1000, Aggregation.AVG, AggregationFrequency.FREQ_300, Integer.MAX_VALUE).send();
+
+        // Then
+        ArgumentCaptor<Tags> tagsArg = ArgumentCaptor.forClass(Tags.class);
+
+        verify(metricsSender).aggregatedSampledPut(eq("timer.response_time"), eq("1000"), tagsArg.capture(), eq(Aggregation.AVG), eq(AggregationFrequency.FREQ_300), eq(Integer.MAX_VALUE), eq("application"), anyLong());
+
+        // Then it should have tags
+        shouldContainDefaultTimerTags(tagsArg.getValue());
+    }
+
+    @Test
     public void shouldSendTimerWithTags() {
         // When
         subject.timer("response_time", 1000).with().tag("host", "localhost").tag("cluster", "prod").send();
@@ -244,6 +276,15 @@ public class StatfulClientImplTest {
     }
 
     @Test
+    public void shouldSampledSendCounter() {
+        // When
+        subject.sampledCounter("transactions", 2, Integer.MAX_VALUE).send();
+
+        // Then
+        verify(metricsSender).putSampled(eq("counter.transactions"), eq("2"), any(Tags.class), any(Aggregations.class), eq(AggregationFrequency.FREQ_10), eq(Integer.MAX_VALUE), eq("application"), anyLong());
+    }
+
+    @Test
     public void shouldSendIntegerGaugeMetric() {
         // When
         subject.gauge("current_sessions", 2).send();
@@ -264,6 +305,24 @@ public class StatfulClientImplTest {
 
         // Then
         verify(metricsSender).aggregatedPut(eq("gauge.current_sessions"), eq("2"), isNull(Tags.class), eq(Aggregation.FIRST), eq(AggregationFrequency.FREQ_10), eq(10), eq("application"), anyLong());
+    }
+
+    @Test
+    public void shouldSendIntegerSampledGaugeMetric() {
+        // When
+        subject.sampledGauge("current_sessions", 2, Integer.MAX_VALUE).send();
+
+        // Then
+        verify(metricsSender).putSampled(eq("gauge.current_sessions"), eq("2"), isNull(Tags.class), any(Aggregations.class), any(AggregationFrequency.class), eq(Integer.MAX_VALUE), eq("application"), anyLong());
+    }
+
+    @Test
+    public void shouldSendIntegerSampledAggregatedGaugeMetric() {
+        // When
+        subject.sampledAggregatedGauge("current_sessions", 2, Aggregation.FIRST, AggregationFrequency.FREQ_10, Integer.MAX_VALUE).send();
+
+        // Then
+        verify(metricsSender).aggregatedSampledPut(eq("gauge.current_sessions"), eq("2"), isNull(Tags.class), eq(Aggregation.FIRST), eq(AggregationFrequency.FREQ_10), eq(Integer.MAX_VALUE), eq("application"), anyLong());
     }
 
     @Test
@@ -290,6 +349,24 @@ public class StatfulClientImplTest {
     }
 
     @Test
+    public void shouldSendLongSampledGaugeMetric() {
+        // When
+        subject.sampledGauge("current_sessions", 2L, Integer.MAX_VALUE).send();
+
+        // Then
+        verify(metricsSender).putSampled(eq("gauge.current_sessions"), eq("2"), isNull(Tags.class), any(Aggregations.class), any(AggregationFrequency.class), eq(Integer.MAX_VALUE), eq("application"), anyLong());
+    }
+
+    @Test
+    public void shouldSendLongSampledAggregatedGaugeMetric() {
+        // When
+        subject.sampledAggregatedGauge("current_sessions", 2L, Aggregation.FIRST, AggregationFrequency.FREQ_10, Integer.MAX_VALUE).send();
+
+        // Then
+        verify(metricsSender).aggregatedSampledPut(eq("gauge.current_sessions"), eq("2"), isNull(Tags.class), eq(Aggregation.FIRST), eq(AggregationFrequency.FREQ_10), eq(Integer.MAX_VALUE), eq("application"), anyLong());
+    }
+
+    @Test
     public void shouldSendDoubleGaugeMetric() {
         // When
         subject.gauge("current_sessions", 2.2).send();
@@ -310,6 +387,16 @@ public class StatfulClientImplTest {
 
         // Then
         verify(metricsSender).aggregatedPut(eq("gauge.current_sessions"), eq("2.2"), isNull(Tags.class), eq(Aggregation.FIRST), eq(AggregationFrequency.FREQ_10), eq(10), eq("application"), anyLong());
+    }
+
+    @Test
+    public void shouldSendSampledDoubleGaugeMetric() {
+
+        // When
+        subject.sampledGauge("current_sessions", 2.2, Integer.MAX_VALUE).send();
+
+        // Then
+        verify(metricsSender).putSampled(eq("gauge.current_sessions"), eq("2.2"), isNull(Tags.class), any(Aggregations.class), any(AggregationFrequency.class), eq(Integer.MAX_VALUE), eq("application"), anyLong());
     }
 
     @Test

--- a/core/src/test/java/com/statful/client/core/StatfulClientImplTest.java
+++ b/core/src/test/java/com/statful/client/core/StatfulClientImplTest.java
@@ -400,6 +400,15 @@ public class StatfulClientImplTest {
     }
 
     @Test
+    public void shouldSendDoubleSampledAggregatedGaugeMetric() {
+        // When
+        subject.sampledAggregatedGauge("current_sessions", 2.2, Aggregation.FIRST, AggregationFrequency.FREQ_10, Integer.MAX_VALUE).send();
+
+        // Then
+        verify(metricsSender).aggregatedSampledPut(eq("gauge.current_sessions"), eq("2.2"), isNull(Tags.class), eq(Aggregation.FIRST), eq(AggregationFrequency.FREQ_10), eq(Integer.MAX_VALUE), eq("application"), anyLong());
+    }
+
+    @Test
     public void shouldSendFloatGaugeMetric() {
         // When
         subject.gauge("current_sessions", Float.valueOf("2.3")).send();
@@ -420,6 +429,24 @@ public class StatfulClientImplTest {
 
         // Then
         verify(metricsSender).aggregatedPut(eq("gauge.current_sessions"), eq("2.3"), isNull(Tags.class), eq(Aggregation.FIRST), eq(AggregationFrequency.FREQ_10), eq(10), eq("application"), anyLong());
+    }
+
+    @Test
+    public void shouldSendFloatSampledGaugeMetric() {
+        // When
+        subject.sampledGauge("current_sessions", Float.valueOf("2.3"), Integer.MAX_VALUE).send();
+
+        // Then
+        verify(metricsSender).putSampled(eq("gauge.current_sessions"), eq("2.3"), isNull(Tags.class), any(Aggregations.class), any(AggregationFrequency.class), eq(Integer.MAX_VALUE), eq("application"), anyLong());
+    }
+
+    @Test
+    public void shouldSendFloatSampledAggregatedGaugeMetric() {
+        // When
+        subject.sampledAggregatedGauge("current_sessions", Float.valueOf("2.3"), Aggregation.FIRST, AggregationFrequency.FREQ_10, Integer.MAX_VALUE).send();
+
+        // Then
+        verify(metricsSender).aggregatedSampledPut(eq("gauge.current_sessions"), eq("2.3"), isNull(Tags.class), eq(Aggregation.FIRST), eq(AggregationFrequency.FREQ_10), eq(Integer.MAX_VALUE), eq("application"), anyLong());
     }
 
     @Test
@@ -498,6 +525,26 @@ public class StatfulClientImplTest {
     }
 
     @Test
+    public void shouldSendSimpleIntegerSampledMetric() {
+        // When
+        subject.sampledPut("response_time", 1000, Integer.MAX_VALUE).send();
+
+
+        verify(metricsSender).putSampled(eq("response_time"), eq("1000"), any(Tags.class), any(Aggregations.class), any(AggregationFrequency.class), eq(Integer.MAX_VALUE), eq("application"), anyLong());
+    }
+
+    @Test
+    public void shouldSendSimpleIntegerSampledAggregatedMetric() {
+        // When
+        subject.sampledAggregatedPut("response_time", 1000, Aggregation.AVG, AggregationFrequency.FREQ_10, Integer.MAX_VALUE).send();
+
+        // Then
+        ArgumentCaptor<Tags> tagsArg = ArgumentCaptor.forClass(Tags.class);
+
+        verify(metricsSender).aggregatedSampledPut(eq("response_time"), eq("1000"), tagsArg.capture(), eq(Aggregation.AVG), eq(AggregationFrequency.FREQ_10), eq(Integer.MAX_VALUE), eq("application"), anyLong());
+    }
+
+    @Test
     public void shouldSendSimpleLongAggregatedMetric() {
         // When
         subject.aggregatedPut("response_time", 1000L, Aggregation.AVG, AggregationFrequency.FREQ_10).send();
@@ -506,6 +553,17 @@ public class StatfulClientImplTest {
         ArgumentCaptor<Tags> tagsArg = ArgumentCaptor.forClass(Tags.class);
 
         verify(metricsSender).aggregatedPut(eq("response_time"), eq("1000"), tagsArg.capture(), eq(Aggregation.AVG), eq(AggregationFrequency.FREQ_10), eq(10), eq("application"), anyLong());
+    }
+
+    @Test
+    public void shouldSendSimpleLongSampledAggregatedMetric() {
+        // When
+        subject.sampledAggregatedPut("response_time", 1000L, Aggregation.AVG, AggregationFrequency.FREQ_10, Integer.MAX_VALUE).send();
+
+        // Then
+        ArgumentCaptor<Tags> tagsArg = ArgumentCaptor.forClass(Tags.class);
+
+        verify(metricsSender).aggregatedSampledPut(eq("response_time"), eq("1000"), tagsArg.capture(), eq(Aggregation.AVG), eq(AggregationFrequency.FREQ_10), eq(Integer.MAX_VALUE), eq("application"), anyLong());
     }
 
     @Test
@@ -520,6 +578,24 @@ public class StatfulClientImplTest {
     }
 
     @Test
+    public void shouldSendSimpleFloatSampledMetric() {
+        // When
+        subject.sampledPut("response_time", 1000F, Integer.MAX_VALUE).send();
+
+        // Then
+        verify(metricsSender).putSampled(eq("response_time"), eq("1000.0"), any(Tags.class), any(Aggregations.class), any(AggregationFrequency.class), eq(Integer.MAX_VALUE), eq("application"), anyLong());
+    }
+
+    @Test
+    public void shouldSendSimpleFloatSampledAggregatedMetric() {
+        // When
+        subject.sampledAggregatedPut("response_time", 1000F,Aggregation.AVG, AggregationFrequency.FREQ_10, Integer.MAX_VALUE).send();
+
+        // Then
+        verify(metricsSender).aggregatedSampledPut(eq("response_time"), eq("1000.0"), any(Tags.class), eq(Aggregation.AVG), eq(AggregationFrequency.FREQ_10), eq(Integer.MAX_VALUE), eq("application"), anyLong());
+    }
+
+    @Test
     public void shouldSendSimpleDoubleAggregatedMetric() {
         // When
         subject.aggregatedPut("response_time", 1000D, Aggregation.AVG, AggregationFrequency.FREQ_10).send();
@@ -528,6 +604,17 @@ public class StatfulClientImplTest {
         ArgumentCaptor<Tags> tagsArg = ArgumentCaptor.forClass(Tags.class);
 
         verify(metricsSender).aggregatedPut(eq("response_time"), eq("1000.0"), tagsArg.capture(), eq(Aggregation.AVG), eq(AggregationFrequency.FREQ_10), eq(10), eq("application"), anyLong());
+    }
+
+    @Test
+    public void shouldSendSimpleDoubleSampledAggregatedMetric() {
+        // When
+        subject.sampledAggregatedPut("response_time", 1000D, Aggregation.AVG, AggregationFrequency.FREQ_10, Integer.MAX_VALUE).send();
+
+        // Then
+        ArgumentCaptor<Tags> tagsArg = ArgumentCaptor.forClass(Tags.class);
+
+        verify(metricsSender).aggregatedSampledPut(eq("response_time"), eq("1000.0"), tagsArg.capture(), eq(Aggregation.AVG), eq(AggregationFrequency.FREQ_10), eq(Integer.MAX_VALUE), eq("application"), anyLong());
     }
 
     @Test
@@ -748,6 +835,23 @@ public class StatfulClientImplTest {
         ArgumentCaptor<Tags> tagsArg = ArgumentCaptor.forClass(Tags.class);
 
         verify(metricsSender).aggregatedPut(eq("timer.response_time"), eq("1000"), tagsArg.capture(), eq(Aggregation.AVG), eq(AggregationFrequency.FREQ_10), eq(10), eq("application"), eq(100000L));
+
+        // Then it should have tags
+        shouldContainDefaultTimerTags(tagsArg.getValue());
+    }
+
+    @Test
+    public void shouldPutRawSampledMetrics() {
+        // When
+        Tags tags = new Tags();
+        tags.putTag("unit", "ms");
+
+        subject.putSampled("timer.response_time", "1000", tags, Aggregations.from(Aggregation.AVG), AggregationFrequency.FREQ_10, Integer.MAX_VALUE, "application", 100000);
+
+        // Then
+        ArgumentCaptor<Tags> tagsArg = ArgumentCaptor.forClass(Tags.class);
+
+        verify(metricsSender).putSampled(eq("timer.response_time"), eq("1000"), tagsArg.capture(), any(Aggregations.class), eq(AggregationFrequency.FREQ_10), eq(Integer.MAX_VALUE), eq("application"), eq(100000L));
 
         // Then it should have tags
         shouldContainDefaultTimerTags(tagsArg.getValue());

--- a/core/src/test/java/com/statful/client/core/api/MetricsSenderAPITest.java
+++ b/core/src/test/java/com/statful/client/core/api/MetricsSenderAPITest.java
@@ -50,7 +50,7 @@ public class MetricsSenderAPITest {
 
     @Test
     public void shouldNotSendWhenAggregatedMetricIsInvalid() {
-        MetricsSenderAPI builder = new MetricsSenderAPI(metricsSender, true);
+        MetricsSenderAPI builder = new MetricsSenderAPI(metricsSender, true, false);
         builder.name("something").value("something").aggregations(Aggregations.from(Aggregation.AVG, Aggregation.COUNT));
 
         builder.send();

--- a/domain/src/main/java/com/statful/client/domain/api/MetricsSender.java
+++ b/domain/src/main/java/com/statful/client/domain/api/MetricsSender.java
@@ -23,6 +23,24 @@ public interface MetricsSender {
     /**
      * Puts a metric to be ready to sent to Statful. This can be done immediately, or by an asynchronous flush mechanism.
      *
+     * This metric is considered to have been already sampled so no sampling will be applied by the client and will just
+     * push that information to the server when flushing
+     *
+     * @param name The name of the metric
+     * @param value The value of the metric
+     * @param tags A {@link Tags} the tags to be associated with the metric
+     * @param aggregations {@link Aggregations} with aggregations of the metric
+     * @param aggregationFrequency {@link AggregationFrequency} of the metric
+     * @param sampleRate The metrics sample rate
+     * @param namespace The namespace of the metric
+     * @param timestamp The timestamp associated with the metric
+     */
+    void putSampled(String name, String value, Tags tags, Aggregations aggregations, AggregationFrequency aggregationFrequency,
+                    Integer sampleRate, String namespace, long timestamp);
+
+    /**
+     * Puts a metric to be ready to sent to Statful. This can be done immediately, or by an asynchronous flush mechanism.
+     *
      * @param name The name of the metric
      * @param value The value of the metric
      * @param tags A {@link Tags} the tags to be associated with the metric
@@ -34,6 +52,24 @@ public interface MetricsSender {
      */
     void aggregatedPut(String name, String value, Tags tags, Aggregation aggregation, AggregationFrequency aggregationFrequency,
                        Integer sampleRate, String namespace, long timestamp);
+
+    /**
+     * Puts a metric to be ready to sent to Statful. This can be done immediately, or by an asynchronous flush mechanism.
+     *
+     * This metric is considered to have been already sampled so no sampling will be applied by the client and will just
+     * push that information to the server when flushing
+     *
+     * @param name The name of the metric
+     * @param value The value of the metric
+     * @param tags A {@link Tags} the tags to be associated with the metric
+     * @param aggregation A {@link Aggregation} aggregation of the metric
+     * @param aggregationFrequency A {@link AggregationFrequency} aggregation frequency of the metric
+     * @param sampleRate The metrics sample rate
+     * @param namespace The namespace of the metric
+     * @param timestamp The timestamp associated with the metric
+     */
+    void aggregatedSampledPut(String name, String value, Tags tags, Aggregation aggregation, AggregationFrequency aggregationFrequency,
+                              Integer sampleRate, String namespace, long timestamp);
 
     /**
      * Forces synchronous flush of metrics. This method blocks the caller.

--- a/domain/src/main/java/com/statful/client/domain/api/StatfulClient.java
+++ b/domain/src/main/java/com/statful/client/domain/api/StatfulClient.java
@@ -109,6 +109,148 @@ public interface StatfulClient extends MetricsSender {
     SenderFacade put(final String metricName, final Integer value);
 
     /**
+     * Creates a new timer metrics builder.
+     *
+     * This metric is considered to have been already sampled so no sampling will be applied by the client and will just
+     * push that information to the server when flushing
+     *
+     * @param metricName The timer name to create
+     * @param value The timer value to send to Statful
+     * @param sampleRate The sample rate applied
+     * @return A {@link SenderFacade}, ready to send or to configure a metric before sending
+     */
+    SenderFacade sampledTimer(final String metricName, final long value, final Integer sampleRate);
+
+    /**
+     * Creates a new counter metrics builder, which increments by one by default.
+     *
+     * This metric is considered to have been already sampled so no sampling will be applied by the client and will just
+     * push that information to the server when flushing
+     *
+     * @param metricName The counter name to create
+     * @param sampleRate The sample rate applied
+     * @return A {@link SenderFacade}, ready to send or to configure a metric before sending
+     */
+    SenderFacade sampledCounter(final String metricName, final Integer sampleRate);
+
+    /**
+     * Creates a new counter metrics builder.
+     *
+     * This metric is considered to have been already sampled so no sampling will be applied by the client and will just
+     * push that information to the server when flushing
+     *
+     * @param metricName The counter name to create
+     * @param value The counter increment value to send to Statful
+     * @param sampleRate The sample rate applied
+     * @return A {@link SenderFacade}, ready to send or to configure a metric before sending
+     */
+    SenderFacade sampledCounter(final String metricName, final int value, final Integer sampleRate);
+
+    /**
+     * Creates a new gauge metrics builder.
+     *
+     * This metric is considered to have been already sampled so no sampling will be applied by the client and will just
+     * push that information to the server when flushing
+     *
+     * @param metricName The gauge name to create
+     * @param value The gauge value to send to Statful
+     * @param sampleRate The sample rate applied
+     * @return A {@link SenderFacade}, ready to send or to configure a metric before sending
+     */
+    SenderFacade sampledGauge(final String metricName, final Long value, final Integer sampleRate);
+
+    /**
+     * Creates a new gauge metrics builder.
+     *
+     * This metric is considered to have been already sampled so no sampling will be applied by the client and will just
+     * push that information to the server when flushing
+     *
+     * @param metricName The gauge name to create
+     * @param value The gauge value to send to Statful
+     * @param sampleRate The sample rate applied
+     * @return A {@link SenderFacade}, ready to send or to configure a metric before sending
+     */
+    SenderFacade sampledGauge(final String metricName, final Double value, final Integer sampleRate);
+
+    /**
+     * Creates a new gauge metrics builder.
+     *
+     * This metric is considered to have been already sampled so no sampling will be applied by the client and will just
+     * push that information to the server when flushing
+     *
+     * @param metricName The gauge name to create
+     * @param value The gauge value to send to Statful
+     * @param sampleRate The sample rate applied
+     * @return A {@link SenderFacade}, ready to send or to configure a metric before sending
+     */
+    SenderFacade sampledGauge(final String metricName, final Float value, final Integer sampleRate);
+
+    /**
+     * Creates a new gauge metrics builder.
+     *
+     * This metric is considered to have been already sampled so no sampling will be applied by the client and will just
+     * push that information to the server when flushing
+     *
+     * @param metricName The gauge name to create
+     * @param value The gauge value to send to Statful
+     * @param sampleRate The sample rate applied
+     * @return A {@link SenderFacade}, ready to send or to configure a metric before sending
+     */
+    SenderFacade sampledGauge(final String metricName, final Integer value, final Integer sampleRate);
+
+    /**
+     * Creates a new simple put builder.
+     *
+     * This metric is considered to have been already sampled so no sampling will be applied by the client and will just
+     * push that information to the server when flushing
+     *
+     * @param metricName The metric name to create
+     * @param value The metric value to send to Statful
+     * @param sampleRate The sample rate applied
+     * @return A {@link SenderFacade}, ready to send or to configure a metric before sending
+     */
+    SenderFacade sampledPut(final String metricName, final Long value, final Integer sampleRate);
+
+    /**
+     * Creates a new simple put builder.
+     *
+     * This metric is considered to have been already sampled so no sampling will be applied by the client and will just
+     * push that information to the server when flushing
+     *
+     * @param metricName The metric name to create
+     * @param value The metric value to send to Statful
+     * @param sampleRate The sample rate applied
+     * @return A {@link SenderFacade}, ready to send or to configure a metric before sending
+     */
+    SenderFacade sampledPut(final String metricName, final Double value, final Integer sampleRate);
+
+    /**
+     * Creates a new simple put builder.
+     *
+     * This metric is considered to have been already sampled so no sampling will be applied by the client and will just
+     * push that information to the server when flushing
+     *
+     * @param metricName The metric name to create
+     * @param value The metric value to send to Statful
+     * @param sampleRate The sample rate applied
+     * @return A {@link SenderFacade}, ready to send or to configure a metric before sending
+     */
+    SenderFacade sampledPut(final String metricName, final Float value, final Integer sampleRate);
+
+    /**
+     * Creates a new simple put builder.
+     *
+     * This metric is considered to have been already sampled so no sampling will be applied by the client and will just
+     * push that information to the server when flushing
+     *
+     * @param metricName The metric name to create
+     * @param value The metric value to send to Statful
+     * @param sampleRate The sample rate applied
+     * @return A {@link SenderFacade}, ready to send or to configure a metric before sending
+     */
+    SenderFacade sampledPut(final String metricName, final Integer value, final Integer sampleRate);
+
+    /**
      * Creates a new aggregated timer metrics builder.
      *
      * @param metricName The timer name to create
@@ -227,6 +369,166 @@ public interface StatfulClient extends MetricsSender {
      */
     SenderFacade aggregatedPut(final String metricName, final Integer value, final Aggregation aggregation,
                                final AggregationFrequency aggregationFrequency);
+
+    /**
+     * Creates a new aggregated timer metrics builder.
+     *
+     * This metric is considered to have been already sampled so no sampling will be applied by the client and will just
+     * push that information to the server when flushing
+     *
+     * @param metricName The timer name to create
+     * @param timestamp The timer timestamp value to send to Statful
+     * @param aggregation The aggregation applied
+     * @param aggregationFrequency The aggregation frequency applied
+     * @param sampleRate The sample rate applied
+     * @return A {@link SenderFacade}, ready to send or to configure a metric before sending
+     */
+    SenderFacade sampledAggregatedTimer(final String metricName, final long timestamp, final Aggregation aggregation,
+                                 final AggregationFrequency aggregationFrequency, final Integer sampleRate);
+
+    /**
+     * Creates a new aggregated counter metrics builder.
+     *
+     * This metric is considered to have been already sampled so no sampling will be applied by the client and will just
+     * push that information to the server when flushing
+     *
+     * @param metricName The counter name to create
+     * @param value The counter increment value to send to Statful
+     * @param aggregation The aggregation applied
+     * @param aggregationFrequency The aggregation frequency applied
+     * @param sampleRate The sample rate applied
+     * @return A {@link SenderFacade}, ready to send or to configure a metric before sending
+     */
+    SenderFacade sampledAggregatedCounter(final String metricName, final int value, final Aggregation aggregation,
+                                   final AggregationFrequency aggregationFrequency, final Integer sampleRate);
+
+    /**
+     * Creates a new aggregated gauge metrics builder.
+     *
+     * This metric is considered to have been already sampled so no sampling will be applied by the client and will just
+     * push that information to the server when flushing
+     *
+     * @param metricName The gauge name to create
+     * @param value The gauge value to send to Statful
+     * @param aggregation The aggregation applied
+     * @param aggregationFrequency The aggregation frequency applied
+     * @param sampleRate The sample rate applied
+     * @return A {@link SenderFacade}, ready to send or to configure a metric before sending
+     */
+    SenderFacade sampledAggregatedGauge(final String metricName, final Long value, final Aggregation aggregation,
+                                 final AggregationFrequency aggregationFrequency, final Integer sampleRate);
+
+    /**
+     * Creates a new aggregated gauge metrics builder.
+     *
+     * This metric is considered to have been already sampled so no sampling will be applied by the client and will just
+     * push that information to the server when flushing
+     *
+     * @param metricName The gauge name to create
+     * @param value The gauge value to send to Statful
+     * @param aggregation The aggregation applied
+     * @param aggregationFrequency The aggregation frequency applied
+     * @param sampleRate The sample rate applied
+     * @return A {@link SenderFacade}, ready to send or to configure a metric before sending
+     */
+    SenderFacade sampledAggregatedGauge(final String metricName, final Double value, final Aggregation aggregation,
+                                 final AggregationFrequency aggregationFrequency, final Integer sampleRate);
+
+    /**
+     * Creates a new aggregated gauge metrics builder.
+     *
+     * This metric is considered to have been already sampled so no sampling will be applied by the client and will just
+     * push that information to the server when flushing
+     *
+     * @param metricName The gauge name to create
+     * @param value The gauge value to send to Statful
+     * @param aggregation The aggregation applied
+     * @param aggregationFrequency The aggregation frequency applied
+     * @param sampleRate The sample rate applied
+     * @return A {@link SenderFacade}, ready to send or to configure a metric before sending
+     */
+    SenderFacade sampledAggregatedGauge(final String metricName, final Float value, final Aggregation aggregation,
+                                 final AggregationFrequency aggregationFrequency, final Integer sampleRate);
+
+    /**
+     * Creates a new aggregated gauge metrics builder.
+     *
+     * This metric is considered to have been already sampled so no sampling will be applied by the client and will just
+     * push that information to the server when flushing
+     *
+     * @param metricName The gauge name to create
+     * @param value The gauge value to send to Statful
+     * @param aggregation The aggregation applied
+     * @param aggregationFrequency The aggregation frequency applied
+     * @param sampleRate The sample rate applied
+     * @return A {@link SenderFacade}, ready to send or to configure a metric before sending
+     */
+    SenderFacade sampledAggregatedGauge(final String metricName, final Integer value, final Aggregation aggregation,
+                                 final AggregationFrequency aggregationFrequency, final Integer sampleRate);
+
+    /**
+     * Creates a new simple aggregated put builder.
+     *
+     * This metric is considered to have been already sampled so no sampling will be applied by the client and will just
+     * push that information to the server when flushing
+     *
+     * @param metricName The metric name to create
+     * @param value The metric value to send to Statful
+     * @param aggregation The aggregation applied
+     * @param aggregationFrequency The aggregation frequency applied
+     * @param sampleRate The sample rate applied
+     * @return A {@link SenderFacade}, ready to send or to configure a metric before sending
+     */
+    SenderFacade sampledAggregatedPut(final String metricName, final Long value, final Aggregation aggregation,
+                               final AggregationFrequency aggregationFrequency, final Integer sampleRate);
+
+    /**
+     * Creates a new simple aggregated put builder.
+     *
+     * This metric is considered to have been already sampled so no sampling will be applied by the client and will just
+     * push that information to the server when flushing
+     *
+     * @param metricName The metric name to create
+     * @param value The metric value to send to Statful
+     * @param aggregation The aggregation applied
+     * @param aggregationFrequency The aggregation frequency applied
+     * @param sampleRate The sample rate applied
+     * @return A {@link SenderFacade}, ready to send or to configure a metric before sending
+     */
+    SenderFacade sampledAggregatedPut(final String metricName, final Double value, final Aggregation aggregation,
+                               final AggregationFrequency aggregationFrequency, final Integer sampleRate);
+
+    /**
+     * Creates a new simple aggregated put builder.
+     *
+     * This metric is considered to have been already sampled so no sampling will be applied by the client and will just
+     * push that information to the server when flushing
+     *
+     * @param metricName The metric name to create
+     * @param value The metric value to send to Statful
+     * @param aggregation The aggregation applied
+     * @param aggregationFrequency The aggregation frequency applied
+     * @param sampleRate The sample rate applied
+     * @return A {@link SenderFacade}, ready to send or to configure a metric before sending
+     */
+    SenderFacade sampledAggregatedPut(final String metricName, final Float value, final Aggregation aggregation,
+                               final AggregationFrequency aggregationFrequency, final Integer sampleRate);
+
+    /**
+     * Creates a new simple aggregated put builder.
+     *
+     * This metric is considered to have been already sampled so no sampling will be applied by the client and will just
+     * push that information to the server when flushing
+     *
+     * @param metricName The metric name to create
+     * @param value The metric value to send to Statful
+     * @param aggregation The aggregation applied
+     * @param aggregationFrequency The aggregation frequency applied
+     * @param sampleRate The sample rate applied
+     * @return A {@link SenderFacade}, ready to send or to configure a metric before sending
+     */
+    SenderFacade sampledAggregatedPut(final String metricName, final Integer value, final Aggregation aggregation,
+                               final AggregationFrequency aggregationFrequency, final Integer sampleRate);
 
     /**
      * Enables Statful client.


### PR DESCRIPTION
Expose methods so that the consumer can send metrics that are already sampled before being ingested.

This allows statful to render correctly metrics that were already sampled