### PR TITLE
fix(#15) - Update default host and port transport values

### DIFF
--- a/core/src/main/java/com/statful/client/core/config/DefaultClientConfiguration.java
+++ b/core/src/main/java/com/statful/client/core/config/DefaultClientConfiguration.java
@@ -15,9 +15,9 @@ public class DefaultClientConfiguration implements ClientConfiguration {
     private static final int MAX_TASKS_QUEUE_SIZE = 100;
     private static final long TASK_KILLER_INTERVAL = 30000;
 
-    private static final String DEFAULT_HOST = "127.0.0.1";
+    private static final String DEFAULT_HOST = "api.statful.com";
     private static final boolean DEFAULT_SECURE = true;
-    private static final int DEFAULT_PORT = 2013;
+    private static final int DEFAULT_PORT = 443;
     private static final String DEFAULT_PATH = "/tel/v2.0/metrics";
     private static final int DEFAULT_SAMPLE_RATE = 100;
     private static final String DEFAULT_NAMESPACE = "application";

--- a/core/src/test/java/com/statful/client/core/api/ConfigurationBuilderTest.java
+++ b/core/src/test/java/com/statful/client/core/api/ConfigurationBuilderTest.java
@@ -12,6 +12,7 @@ import static com.statful.client.core.api.MetricBuilder.*;
 import static com.statful.client.domain.api.Aggregation.*;
 import static com.statful.client.domain.api.AggregationFrequency.FREQ_10;
 import static com.statful.client.domain.api.AggregationFrequency.FREQ_120;
+import static com.statful.client.domain.api.Transport.HTTP;
 import static com.statful.client.domain.api.Transport.UDP;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -28,11 +29,11 @@ public class ConfigurationBuilderTest {
     @Test
     public void shouldUseDefaultValuesWhenNoneAreSpecified() {
         ClientConfiguration config = newBuilder()
-                .transport(UDP)
+                .transport(HTTP)
                 .buildConfiguration();
 
-        assertEquals("Should have default host", "127.0.0.1", config.getHost());
-        assertEquals("Should have default port", 2013, config.getPort());
+        assertEquals("Should have default host", "api.statful.com", config.getHost());
+        assertEquals("Should have default port", 443, config.getPort());
         assertFalse("Should not dry run as default", config.isDryRun());
         assertEquals("Should have default sample rate", 100, config.getSampleRate());
         assertEquals("Should have default namespace", "application", config.getNamespace());

--- a/core/src/test/java/com/statful/client/core/config/DefaultClientConfigurationTest.java
+++ b/core/src/test/java/com/statful/client/core/config/DefaultClientConfigurationTest.java
@@ -203,8 +203,8 @@ public class DefaultClientConfigurationTest {
     @Test
     public void shouldHaveDefaultConfigurationValues() {
 
-        assertEquals("127.0.0.1", subject.getHost());
-        assertEquals(2013, subject.getPort());
+        assertEquals("api.statful.com", subject.getHost());
+        assertEquals(443, subject.getPort());
         assertEquals(100, subject.getSampleRate());
         assertEquals("/tel/v2.0/metrics", subject.getPath());
         assertEquals("application", subject.getNamespace());

--- a/udp-client/src/test/java/com/statful/client/core/udp/StatfulFactoryTest.java
+++ b/udp-client/src/test/java/com/statful/client/core/udp/StatfulFactoryTest.java
@@ -21,6 +21,8 @@ public class StatfulFactoryTest {
 
         // When
         StatfulClient client = StatfulFactory.buildUDPClient().with()
+                .host("localhost")
+                .port(2013)
                 .flushSize(1)
                 .build();
         client.counter("test_counter").send();
@@ -33,7 +35,11 @@ public class StatfulFactoryTest {
 
     @Test
     public void shouldCreateUDPClientWithoutOptionalConfigurations() {
-        StatfulClient client = StatfulFactory.buildUDPClient().build();
+        StatfulClient client = StatfulFactory.buildUDPClient()
+                .with()
+                .host("localhost")
+                .port(2013)
+                .build();
 
         assertNotNull(client);
     }


### PR DESCRIPTION
This will default the client to point to "api.statful.com" on port "443" by default. It has the potential of breaking existing clients so it will be a breaking change and the version will have to reflect it.

Fixes #15 